### PR TITLE
fix/i18n: remove footer translation keys to use keycloak translation

### DIFF
--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -28,7 +28,7 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
 
     const { kcClsx } = getKcClsx({ doUseDefaultCss, classes });
 
-    const { msg, msgStr, currentLanguage, enabledLanguages } = i18n;
+    const { msg, msgStr, advancedMsgStr, currentLanguage, enabledLanguages } = i18n;
 
     const { realm, auth, url, message, isAppInitiatedAction } = kcContext;
 
@@ -189,22 +189,22 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
             </div>
             <footer className={"flex justify-between max-w-md w-full mt-8 relative"}>
                 <section className={"flex flex-col ml-5"}>
-                    {(msgStr("footerImprintUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_IMPRINT_URL"]) && (
+                    {(advancedMsgStr("footerImprintUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_IMPRINT_URL"]) && (
                         <a
                             className={"text-secondary-600 hover:text-secondary-900 text-sm inline-flex no-underline hover:no-underline"}
                             target={"_blank"}
                             rel={"noopener noreferrer"}
-                            href={msgStr("footerImprintUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_IMPRINT_URL"]}
+                            href={advancedMsgStr("footerImprintUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_IMPRINT_URL"]}
                         >
                             {msg("footerImprintTitle")}
                         </a>
                     )}
-                    {(msgStr("footerDataprotectionUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_DATAPROTECTION_URL"]) && (
+                    {(advancedMsgStr("footerDataprotectionUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_DATAPROTECTION_URL"]) && (
                         <a
                             className={"text-secondary-600 hover:text-secondary-900 text-sm inline-flex no-underline hover:no-underline"}
                             target={"_blank"}
                             rel={"noopener noreferrer"}
-                            href={msgStr("footerDataprotectionUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_DATAPROTECTION_URL"]}
+                            href={advancedMsgStr("footerDataprotectionUrl") || kcContext.properties["TAILCLOAKIFY_FOOTER_DATAPROTECTION_URL"]}
                         >
                             {msg("footerDataProtectionTitle")}
                         </a>

--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -10,30 +10,22 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             footerImprintTitle: "Imprint",
             footerDataProtectionTitle: "Data Protection",
             footerCookiePreferencesTitle: "Cookie Preferences",
-            footerImprintUrl: '',
-            footerDataprotectionUrl: '',
         },
         de: {
             footerImprintTitle: "Impressum",
             footerDataProtectionTitle: "Datenschutz",
             footerCookiePreferencesTitle: "Cookie Einstellungen",
-            footerImprintUrl: '',
-            footerDataprotectionUrl: '',
         },
         fr: {
             footerImprintTitle: "Mentions Légales",
             footerDataProtectionTitle: "Protection des Données",
             footerCookiePreferencesTitle: "Paramètres des Cookies",
-            footerImprintUrl: '',
-            footerDataprotectionUrl: '',
         },
         it: {
             footerImprintTitle: "Impronta",
             footerDataProtectionTitle: "Informativa sulla Privacy",
             footerCookiePreferencesTitle: "Impostazioni dei Cookie",
-            footerImprintUrl: '',
-            footerDataprotectionUrl: '',
-        }
+        },
     })
     .build();
 


### PR DESCRIPTION
Localization Variables for the multilingual footer links are not reconized.
I have reworked the implementation to use the server localization as intended.

https://docs.keycloakify.dev/features/i18n/adding-new-translation-messages-or-changing-the-default-ones