### PR TITLE
fix: opening of cookie consent by using global method

### DIFF
--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -218,7 +218,7 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
                             target={"_blank"}
                             rel={"noopener noreferrer"}
                             type={"button"}
-                            data-cc={"show-preferencesModal"}
+                            onClick={() => window.CookieConsent?.showPreferences()}
                         >
                             {msg("footerCookiePreferencesTitle")}
                         </a>


### PR DESCRIPTION
@waynemorphic i had trouble opening the CookieConsent, when the CookieConsent object was loaded from an external skript, like on the ALMiG website. therefore I will opening the dialog by accessing it directly.

I guess this is related to react and the binding between the html element (initialized by script), which can get los, when the site is repainted.

Can you please test this aproach as well, before we gonna merge it :)