### PR TITLE
fix: Render the correct login URL in the magic link email

### DIFF
--- a/src/email/templates/magic-link-email.tsx
+++ b/src/email/templates/magic-link-email.tsx
@@ -35,7 +35,7 @@ export const Template = ({ locale, t }: TemplateProps) => (
         <Text style={paragraph}>
             <p>{t("magic-link-email.messageBody", { realmName: exp("realmName") })}</p>
             <p>
-                <a href={exp("url.loginUrl")}>{t("magic-link-email.magicLink")}</a>
+                <a href={exp("magicLink")}>{t("magic-link-email.magicLink")}</a>
             </p>
         </Text>
     </EmailLayout>

--- a/src/email/util/VariablesHelper.ts
+++ b/src/email/util/VariablesHelper.ts
@@ -47,11 +47,15 @@ type OrganizationInvite = {
 
 /*
 * Phase Two
-* */
+ * */
+type MagicLinkVars = {
+  magicLink: string;
+};
+
 type MagicLinkEmail = {
     emailId: "magic-link-email.ftl";
     vars: Path<
-        BaseVars & LinkVars
+        BaseVars & LinkVars & MagicLinkVars
     >;
 };
 


### PR DESCRIPTION
Fix [Wrong login URL in the customized "magic link email"](https://github.com/ALMiG-Kompressoren-GmbH/tailcloakify/issues/80)